### PR TITLE
Fixed wget SSL error

### DIFF
--- a/files/ar150/DHCP-AP-Gateway/dhcp-ap-gateway-script.txt
+++ b/files/ar150/DHCP-AP-Gateway/dhcp-ap-gateway-script.txt
@@ -6,7 +6,7 @@ echo src/gz pittmesh openwrt.metamesh.org>> /etc/opkg.conf
 opkg update
 
 # Install a whole mess of packages to use with OLSR, iptables, and supporting packages.
-opkg install luci luci-ssl pciutils luci-app-olsr luci-app-olsr-services luci-app-olsr-viz olsrd olsrd-mod-arprefresh olsrd-mod-bmf olsrd-mod-dot-draw olsrd-mod-dyn-gw olsrd-mod-dyn-gw-plain olsrd-mod-httpinfo olsrd-mod-mdns olsrd-mod-nameservice olsrd-mod-p2pd olsrd-mod-pgraph olsrd-mod-secure olsrd-mod-txtinfo olsrd-mod-watchdog olsrd-mod-quagga wireless-tools luci-lib-json kmod-ipip ethtool snmpd iptables-mod-extra iptables-mod-iface iptables-mod-iprange
+opkg install luci luci-ssl pciutils luci-app-olsr luci-app-olsr-services luci-app-olsr-viz olsrd olsrd-mod-arprefresh olsrd-mod-bmf olsrd-mod-dot-draw olsrd-mod-dyn-gw olsrd-mod-dyn-gw-plain olsrd-mod-httpinfo olsrd-mod-mdns olsrd-mod-nameservice olsrd-mod-p2pd olsrd-mod-pgraph olsrd-mod-secure olsrd-mod-txtinfo olsrd-mod-watchdog olsrd-mod-quagga wireless-tools luci-lib-json kmod-ipip ethtool snmpd iptables-mod-extra iptables-mod-iface iptables-mod-iprange wget ca-certificates
 
 # Check for updates to any packages
 for i in `opkg list-upgradable|cut -d " " -f 1`;do opkg install $i;done


### PR DESCRIPTION
Fixed the wget SSL error when downloading the script form raw.github.com by adding wget and ca-certificates to the opkg install list. 
