### PR TITLE
Set our OpenWRT repository server to be used.

### DIFF
--- a/files/ar150/DHCP-AP-Gateway/dhcp-ap-gateway-script.txt
+++ b/files/ar150/DHCP-AP-Gateway/dhcp-ap-gateway-script.txt
@@ -9,7 +9,14 @@
 # * Justin Goetz
 
 # Update where OpenWRT pulls updates from.
-echo src/gz pittmesh openwrt.metamesh.org>> /etc/opkg.conf
+rm /etc/opkg/distfeeds.conf
+echo src/gz chaos_calmer_base http://openwrt.metamesh.org/chaos_calmer/15.05/ar71xx/generic/packages/base>> /etc/opkg.conf
+echo src/gz chaos_calmer_luci http://openwrt.metamesh.org/chaos_calmer/15.05/ar71xx/generic/packages/luci>> /etc/opkg.conf
+echo src/gz chaos_calmer_management http://openwrt.metamesh.org/chaos_calmer/15.05/ar71xx/generic/packages/management>> /etc/opkg.conf
+echo src/gz chaos_calmer_packages http://openwrt.metamesh.org/chaos_calmer/15.05/ar71xx/generic/packages/packages>> /etc/opkg.conf
+echo src/gz chaos_calmer_routing http://openwrt.metamesh.org/chaos_calmer/15.05/ar71xx/generic/packages/routing>> /etc/opkg.conf
+echo src/gz chaos_calmer_telephony http://openwrt.metamesh.org/chaos_calmer/15.05/ar71xx/generic/packages/telephony>> /etc/opkg.conf
+echo src/gz pittmesh http://openwrt.metamesh.org/pittmesh>> /etc/opkg.conf
 
 opkg update
 


### PR DESCRIPTION
I was asked to set the system's repositories to point to our server. I also added a line to delete the old repositories that seems to be added by the manufacturer, GL-Inet, which would cause interference if not deleted. 
